### PR TITLE
Fix timezone handling

### DIFF
--- a/scripts/glowmarkt-csv
+++ b/scripts/glowmarkt-csv
@@ -50,7 +50,7 @@ try:
             if res.classifier != args.classifier:
                 continue
 
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(datetime.timezone.utc)
             t_from = now - datetime.timedelta(minutes=int(args.minutes))
             t_to = now
 
@@ -77,6 +77,4 @@ try:
 
 except Exception as e:
     print(e)
-
-    raise e
 

--- a/scripts/glowmarkt-dump
+++ b/scripts/glowmarkt-dump
@@ -35,7 +35,7 @@ try:
         for res in ent.get_resources():
             print("  %s:" % res.name)
 
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(datetime.timezone.utc)
             t_from = now - datetime.timedelta(minutes=int(args.minutes))
             t_to = now
 


### PR DESCRIPTION
- Fixed timezone handling.  Times were getting shifted by 1 hour in an unhelpful way during summer time.
- Rounded times to the nearest minute / 30 mins / hour / day depending on the selected period.  This makes the data look like what comes out of the Bright application. I think this is the right thing to do, given that data users are likely to distrust the data if it doesn't match what the official app says.

I think this addresses all the weirdnesses raised in issued #1.