### PR TITLE
Improved date handling and support for null readings

### DIFF
--- a/glowmarkt/glowmarkt.py
+++ b/glowmarkt/glowmarkt.py
@@ -2,7 +2,6 @@
 import requests
 import json
 import datetime
-import time
 
 PT1M = "PT1M"
 PT30M = "PT30M"
@@ -217,19 +216,18 @@ class BrightClient:
 
         utc = datetime.timezone.utc
 
-        # Offset in minutes
-        offset = -t_from.utcoffset().seconds / 60
-
         def time_string(x):
+            """Converts a date or naive datetime instance to a timezone aware datetime instance in UTC and returns a time string in UTC. If its already timezone aware, it will still convert to UTC"""
             if isinstance(x, datetime.datetime):
-                x = x.replace(tzinfo=None)
-                return x.isoformat()
+                x = x.astimezone(utc)  # Converts local timezone with DST, or pre-specified timezones into UTC
+                return x.replace(tzinfo=None).isoformat()   # Remove TZ data without conversion (it's alreadu in UTC), then return ISO string format
             elif isinstance(x, datetime.date):
-                x = x.replace(tzinfo=None)
-                return x.isoformat()
+                x = datetime.datetime.combine(x, datetime.time()).astimezone(utc)   # Adds midnight time components (assumed in local timezone) and converts to UTC
+                return x.replace(tzinfo=None).isoformat()   # Would be similar to t_to.isoformat()[:19] where the +01:00 part is just truncated
             else:
                 raise RuntimeError("to_from/t_to should be date/datetime")
 
+        # Convert to UTC datetimes, conversion will handle tz/dst conversions
         t_from = time_string(t_from)
         t_to = time_string(t_to)
 
@@ -237,7 +235,7 @@ class BrightClient:
             "from": t_from,
             "to": t_to,
             "period": period,
-            "offset": offset,
+            "offset": 0,    # Enforce UTC server side, because we handle TZ/DST conversions client side
             "function": func,
         }
 
@@ -258,9 +256,9 @@ class BrightClient:
             cls = Unknown
 
         return [
-            [datetime.datetime.fromtimestamp(v[0] + 60 * offset).astimezone(),
+            [datetime.datetime.fromtimestamp(v[0], tz=utc).astimezone(),     # Timezone and DST aware datetime in local timezone converted from server side UTC
              cls(v[1])]
-            for v in resp["data"]
+            for v in resp["data"] if v[1]
         ]
 
     def get_current(self, resource):
@@ -295,10 +293,10 @@ class BrightClient:
         else:
             cls = Unknown
 
-        print(datetime.datetime.fromtimestamp(resp["data"][0][0]))
+        print(datetime.datetime.fromtimestamp(resp["data"][0][0]), tz=utc).astimezone()
 
         return [
-            datetime.datetime.fromtimestamp(resp["data"][0][0]).astimezone(),
+            datetime.datetime.fromtimestamp(resp["data"][0][0], tz=utc).astimezone(),
             cls(resp["data"][0][1])
         ]
 
@@ -357,7 +355,7 @@ class BrightClient:
             cls = Unknown
 
         return [
-            [datetime.datetime.fromtimestamp(v[0], tz = utc), cls(v[1])]
+            [datetime.datetime.fromtimestamp(v[0], tz=utc).astimezone(), cls(v[1])]
             for v in resp["data"]
         ]
 


### PR DESCRIPTION
Example code threw exceptions when `datetime.date` or naive (lacking timezone info) `datetime.datetime` objects were used with the `get_reading` method, even though code suggested the intent to support this. I have refactored the code so that all of these are now fully supported. For the same or equivalent inputs using date, datetime, aware and naive forms, the outputs are the same as before.

For more consistency and ease of trouble shooting when comparing to raw API calls, I have also refactored the code so that all transactions to the API for readings are always in UTC (offset=0) so all conversions are handled in Python for parameter input and data returned. I have made these conversions throughout other areas too for consistency, although can't test them all with my data as the API doesn't return anything (or its not implemented).

I have also implemented support for the `nulls` parameter in the `get_readings` method. In the API, when nulls=1 (or True), this allows you to discriminate between a genuine zero and a reading which is missing or not downloaded yet as it returns null (None) instead of zero. In the `get_readings` method, such data is just not returned at all.